### PR TITLE
Add wget as dependency for Debian-based distros in build script

### DIFF
--- a/scripts/build_ngx_pagespeed.sh
+++ b/scripts/build_ngx_pagespeed.sh
@@ -494,7 +494,7 @@ add support for dynamic modules in a way compatible with ngx_pagespeed until
       status "Detected debian-based distro."
 
       install_dependencies "apt-get install ${INSTALL_FLAGS}" debian_is_installed \
-        build-essential zlib1g-dev libpcre3 libpcre3-dev unzip uuid-dev
+        build-essential zlib1g-dev libpcre3 libpcre3-dev unzip wget uuid-dev
 
       if gcc_too_old; then
         if [ ! -e /usr/lib/gcc-mozilla/bin/gcc ]; then


### PR DESCRIPTION
`wget` is a required dependency for the build script but wasn't in the dependency list for Debian-based distros, although it was listed in the Redhat-based distro dependencies. PR simply adds it to the dependency list.

This PR along with the merged #1552 allow the build script to work out-of-the-box on the `ubuntu` Docker image when using `--assume-yes`.