### PR TITLE
Update Nginx in Docker

### DIFF
--- a/docker/alpine-3.8/nginx-mainline/Dockerfile
+++ b/docker/alpine-3.8/nginx-mainline/Dockerfile
@@ -79,7 +79,7 @@ FROM alpine:$ALPINE_VERSION AS nginx
 ARG NGX_PAGESPEED_TAG=v1.13.35.2-stable
 
 # Check http://nginx.org/en/download.html for the latest version.
-ARG NGINX_VERSION=1.15.5
+ARG NGINX_VERSION=1.15.6
 ARG NGINX_PGPKEY=520A9993A1C052F8
 ARG NGINX_BUILD_CONFIG="\
         --prefix=/etc/nginx \
@@ -199,7 +199,7 @@ COPY pagespeed.png /usr/share/nginx/html/
 FROM alpine:$ALPINE_VERSION
 LABEL maintainer="Nico Berlee <nico.berlee@on2it.net>" \
       version.mod-pagespeed="1.13.35.2" \
-      version.nginx="1.15.5" \
+      version.nginx="1.15.6" \
       version.ngx-pagespeed="1.13.35.2"
 
 COPY --from=pagespeed /usr/bin/envsubst /usr/local/bin

--- a/docker/alpine-3.8/nginx-stable/Dockerfile
+++ b/docker/alpine-3.8/nginx-stable/Dockerfile
@@ -79,7 +79,7 @@ FROM alpine:$ALPINE_VERSION AS nginx
 ARG NGX_PAGESPEED_TAG=v1.13.35.2-stable
 
 # Check http://nginx.org/en/download.html for the latest version.
-ARG NGINX_VERSION=1.14.0
+ARG NGINX_VERSION=1.14.1
 ARG NGINX_PGPKEY=520A9993A1C052F8
 ARG NGINX_BUILD_CONFIG="\
         --prefix=/etc/nginx \
@@ -199,7 +199,7 @@ COPY pagespeed.png /usr/share/nginx/html/
 FROM alpine:$ALPINE_VERSION
 LABEL maintainer="Nico Berlee <nico.berlee@on2it.net>" \
       version.mod-pagespeed="1.13.35.2" \
-      version.nginx="1.14.0" \
+      version.nginx="1.14.1" \
       version.ngx-pagespeed="1.13.35.2"
 
 COPY --from=pagespeed /usr/bin/envsubst /usr/local/bin

--- a/docker/alpine-edge/nginx-mainline/Dockerfile
+++ b/docker/alpine-edge/nginx-mainline/Dockerfile
@@ -79,7 +79,7 @@ FROM alpine:$ALPINE_VERSION AS nginx
 ARG NGX_PAGESPEED_TAG=v1.13.35.2-stable
 
 # Check http://nginx.org/en/download.html for the latest version.
-ARG NGINX_VERSION=1.15.5
+ARG NGINX_VERSION=1.15.6
 ARG NGINX_PGPKEY=520A9993A1C052F8
 ARG NGINX_BUILD_CONFIG="\
         --prefix=/etc/nginx \
@@ -199,7 +199,7 @@ COPY pagespeed.png /usr/share/nginx/html/
 FROM alpine:$ALPINE_VERSION
 LABEL maintainer="Nico Berlee <nico.berlee@on2it.net>" \
       version.mod-pagespeed="1.13.35.2" \
-      version.nginx="1.15.5" \
+      version.nginx="1.15.6" \
       version.ngx-pagespeed="1.13.35.2"
 
 COPY --from=pagespeed /usr/bin/envsubst /usr/local/bin

--- a/docker/alpine-edge/nginx-stable/Dockerfile
+++ b/docker/alpine-edge/nginx-stable/Dockerfile
@@ -79,7 +79,7 @@ FROM alpine:$ALPINE_VERSION AS nginx
 ARG NGX_PAGESPEED_TAG=v1.13.35.2-stable
 
 # Check http://nginx.org/en/download.html for the latest version.
-ARG NGINX_VERSION=1.14.0
+ARG NGINX_VERSION=1.14.1
 ARG NGINX_PGPKEY=520A9993A1C052F8
 ARG NGINX_BUILD_CONFIG="\
         --prefix=/etc/nginx \
@@ -204,7 +204,7 @@ COPY pagespeed.png /usr/share/nginx/html/
 FROM alpine:$ALPINE_VERSION
 LABEL maintainer="Nico Berlee <nico.berlee@on2it.net>" \
       version.mod-pagespeed="1.13.35.2" \
-      version.nginx="1.14.0" \
+      version.nginx="1.14.1" \
       version.ngx-pagespeed="1.13.35.2"
 
 COPY --from=pagespeed /usr/bin/envsubst /usr/local/bin


### PR DESCRIPTION
Stable from 1.14.0 to 1.14.1
Mainline from 1.15.5 to 1.15.6

http://nginx.org/en/security_advisories.html