### PR TITLE
removing the word boundary \b

### DIFF
--- a/scripts/format_binary_url.sh
+++ b/scripts/format_binary_url.sh
@@ -37,4 +37,4 @@ else
   bit_size_name=ia32
 fi
 
-sed -e 's/$BIT_SIZE_NAME\b/'$bit_size_name'/g' $url_file
+sed -e 's/$BIT_SIZE_NAME/'$bit_size_name'/g' $url_file


### PR DESCRIPTION
Because of the word boundary \b sed fails to replace $BIT_SIZE_NAME from the binary url in macOS.

Related issue: #1606 