### PR TITLE
Avoids relying on Bash

### DIFF
--- a/scripts/format_binary_url.sh
+++ b/scripts/format_binary_url.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
This script runs fine with just Dash (SH) instead of Bash. Alpine Linux and others don't have Bash.